### PR TITLE
Enhance Kaggle download with masking and environment variable

### DIFF
--- a/.github/workflows/doit.yml
+++ b/.github/workflows/doit.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   KAGGLE_KERNELS_PRIVATE: ${{ vars.KAGGLE_KERNELS_PRIVATE || 'no' }} # by default, do not include private kaggle kernels
+  KAGGLE_KERNELS_MASK: ${{ vars.KAGGLE_KERNELS_MASK || 'yes' }}
   PYTHON_VERSION: ${{ vars.PYTHON_VERSION || '3.11' }}
 
 permissions:


### PR DESCRIPTION
This commit introduces the following enhancements to the Kaggle download process:

* **.github/workflows/doit.yml:** Introduces the `KAGGLE_KERNELS_MASK` environment variable to control adding a mask to downloaded kernel names.
* **main.py:** * Adds the `add_mask` argument to the `main` function for optional masking. * Implements masking logic for kernel name, reference, and downloaded folder path (when `add_mask` is True). * Updates environment variable handling for `include_private` and `add_mask`. * Improves error message handling for hidden kernel names during download failures (when `add_mask` is True).